### PR TITLE
Fix bool flag hangling if default is `true`

### DIFF
--- a/flag.h
+++ b/flag.h
@@ -147,7 +147,7 @@ bool flag_parse(int argc, char **argv)
             if (strcmp(flags[i].name, flag) == 0) {
                 switch (flags[i].type) {
                 case FLAG_BOOL: {
-                    *(bool*)&flags[i].data = true;
+                    *(bool*)&flags[i].data[DATA_VAL] = !*(bool*)&flags[i].data[DATA_DEF];
                 }
                 break;
 


### PR DESCRIPTION
If a boolean flag's default value was true it was not possible to toggle it as a set flag's value was hardcoded to true. This  is fixed by using the negated default value in case the flag is set.