### PR TITLE
Add remaining C numeric types; make default values optional; add ability to mark flags as required

### DIFF
--- a/example.c
+++ b/example.c
@@ -16,6 +16,7 @@ int main(int argc, char **argv)
     bool *help = flag_bool("help", false, "Print this help to stdout and exit with 0");
     char **line = flag_str("line", "Hi!", "Line to output to the file");
     size_t *count = flag_size("count", 64, "Amount of lines to generate");
+    float *test = flag_float("test", 12.0f, "A test float");
 
     if (!flag_parse(argc, argv)) {
         usage(stderr);
@@ -50,6 +51,8 @@ int main(int argc, char **argv)
 
         printf("Generated %" PRIu64 " lines in %s\n", *count, file_path);
     }
+
+    printf("Test: %f\n", *test);
 
     return 0;
 }

--- a/example.c
+++ b/example.c
@@ -13,20 +13,25 @@ void usage(FILE *stream)
 
 int main(int argc, char **argv)
 {
-    bool *help = flag_bool("help", false, "Print this help to stdout and exit with 0");
-    char **line = flag_str("line", "Hi!", "Line to output to the file");
-    size_t *count = flag_size("count", 64, "Amount of lines to generate");
-    float *test = flag_float("test", 12.0f, "A test float");
+    bool *help = flag_bool("help", "Print this help to stdout and exit with 0");
+    char **line = flag_str("line", "Line to output to the file");
+    flag_default(line, "Hey");
+    size_t *count = flag_size("count", "Amount of lines to generate");
+    flag_default(count, 128);
+    flag_required(count, true);
+    float *test = flag_float("test", "A test float");
 
-    if (!flag_parse(argc, argv)) {
-        usage(stderr);
-        flag_print_error(stderr);
-        exit(1);
-    }
+    bool argr = flag_parse(argc, argv);
 
     if (*help) {
         usage(stdout);
         exit(0);
+    }
+
+    if (!argr) {
+        usage(stderr);
+        flag_print_error(stderr);
+        exit(1);
     }
 
     int rest_argc = flag_rest_argc();

--- a/example.c
+++ b/example.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
     char **line = flag_str("line", "Line to output to the file");
     flag_default(line, "Hey");
     size_t *count = flag_size("count", "Amount of lines to generate");
-    flag_default(count, 128);
+    flag_default(count, 128.0f);
     flag_required(count, true);
     float *test = flag_float("test", "A test float");
 

--- a/flag.h
+++ b/flag.h
@@ -53,6 +53,8 @@ char **flag_str (const char *name, const char *desc);
       double*: flag_double_default, \
       default: ((void*)0) \
     )(val, def)
+#elif __cplusplus
+template <typename T> void flag_default(void *val, T def);
 #endif
 
 void flag_bool_default(bool *val, bool def);
@@ -121,7 +123,7 @@ typedef struct Flag_Struct {
     char *name;
     char *desc;
     bool req;
-    uintmax_t val, def;
+    uintptr_t val, def;
 } Flag;
 
 #ifndef FLAGS_CAP
@@ -166,8 +168,17 @@ ctype *flag_ ## mname (const char *name, const char *desc) \
 void flag_ ## mname ## _default(ctype *val, ctype def) \
 { \
     Flag *flag = (Flag*) ((char*) val - offsetof(Flag, val)); \
-    *((ctype*)&(flag->val)) = *((ctype*)&(flag->def)) = def; \
-} 
+    recast(flag->val, ctype) = recast(flag->def, ctype) = def; \
+}
+
+#ifdef __cplusplus
+template<typename T>
+void flag_default(void *val, T def)
+{
+    Flag *flag = (Flag*) ((char*) val - offsetof(Flag, val));
+    flag->val = flag->def = recast(def, uintptr_t);
+}
+#endif
 
 new_flag_impl(FLAG_BOOL, bool, bool)
 new_flag_impl(FLAG_UINT8, uint8_t, uint8)


### PR DESCRIPTION
**Breaks existing API?:** Yes (the `flag_bool`, `flag_str`, etc. functions have a parameter removed)

`flag_[TYPE]_default` functions added to allow the user to specify a default value on a flag, by providing its pointer handle. Similar functionality for `flag_required`.

_On C11-compatible machines or higher, the `flag_default` macro is available (supplied via. `_Generic`), which removes the need to supply a type when setting a default value on a flag._