### PR TITLE
Add alias support

### DIFF
--- a/example.c
+++ b/example.c
@@ -13,9 +13,9 @@ void usage(FILE *stream)
 
 int main(int argc, char **argv)
 {
-    bool *help = flag_bool("help", false, "Print this help to stdout and exit with 0");
-    char **line = flag_str("line", "Hi!", "Line to output to the file");
-    size_t *count = flag_size("count", 64, "Amount of lines to generate");
+    bool *help = flag_bool_aliases("-help", false, "Print this help to stdout and exit with 0", "h");
+    char **line = flag_str_aliases("-line", "Hi!", "Line to output to the file", "l");
+    size_t *count = flag_size_aliases("-count", 64, "Amount of lines to generate", "c");
 
     if (!flag_parse(argc, argv)) {
         usage(stderr);

--- a/example.c
+++ b/example.c
@@ -13,9 +13,13 @@ void usage(FILE *stream)
 
 int main(int argc, char **argv)
 {
-    bool *help = flag_bool_aliases("-help", false, "Print this help to stdout and exit with 0", "h");
-    char **line = flag_str_aliases("-line", "Hi!", "Line to output to the file", "l");
-    size_t *count = flag_size_aliases("-count", 64, "Amount of lines to generate", "c");
+    bool *help = flag_bool("-help", false, "Print this help to stdout and exit with 0");
+    char **line = flag_str("-line", "Hi!", "Line to output to the file");
+    size_t *count = flag_size("-count", 64, "Amount of lines to generate");
+
+    flag_add_alias(help, "h");
+    flag_add_alias(line, "l");
+    flag_add_alias(count, "c");
 
     if (!flag_parse(argc, argv)) {
         usage(stderr);

--- a/flag.h
+++ b/flag.h
@@ -25,6 +25,7 @@
 // WARNING! *_var functions may break the flag_name() functionality
 
 char *flag_name(void *val);
+void flag_add_alias(void *val, const char *alias);
 bool *flag_bool_null(const char *name, bool def, const char *desc, ...);
 #define flag_bool(name, def, desc) flag_bool_null(name, def, desc, NULL)
 #define flag_bool_aliases(name, def, desc, ...)                                        \
@@ -86,7 +87,7 @@ typedef enum {
 typedef struct {
     Flag_Type type;
     char *name;
-    char *aliases[ALIAS_CAP];
+    const char *aliases[ALIAS_CAP];
     size_t alias_count;
     char *desc;
     Flag_Value val;
@@ -121,10 +122,11 @@ Flag *flag_new(Flag_Type type, const char *name, const char *desc, va_list alias
     // NOTE: I won't touch them I promise Kappa
     flag->name = (char*) name;
     flag->desc = (char*) desc;
-    char *alias = va_arg(aliases, char *);
+    const char *alias = va_arg(aliases, const char *);
     while (alias != NULL) {
+        assert(flag->alias_count <= ALIAS_CAP);
         flag->aliases[flag->alias_count++] = alias;
-        alias = va_arg(aliases, char *);
+        alias = va_arg(aliases, const char *);
     }
     return flag;
 }
@@ -133,6 +135,13 @@ char *flag_name(void *val)
 {
     Flag *flag = (Flag*) ((char*) val - offsetof(Flag, val));
     return flag->name;
+}
+
+void flag_add_alias(void *val, const char *alias)
+{
+    Flag *flag = (Flag*) ((char*) val - offsetof(Flag, val));
+    assert(flag->alias_count + 1 <= ALIAS_CAP);
+    flag->aliases[flag->alias_count++] = alias;
 }
 
 bool *flag_bool_null(const char *name, bool def, const char *desc, ...)

--- a/flag.h
+++ b/flag.h
@@ -233,9 +233,11 @@ bool flag_parse(int argc, char **argv)
         for (size_t i = 0; i < c->flags_count; ++i) {
             bool is_name = strcmp(c->flags[i].name, flag) == 0;
             bool is_alias = false;
-            for (size_t j = 0; !is_alias && j < c->flags[i].alias_count; ++j) {
-                if (strcmp(c->flags[i].aliases[j], flag) == 0)
-                    is_alias = true;
+            if (!is_name) {
+                for (size_t j = 0; !is_alias && j < c->flags[i].alias_count; ++j) {
+                    if (strcmp(c->flags[i].aliases[j], flag) == 0)
+                        is_alias = true;
+                }
             }
             if (is_name || is_alias) {
                 static_assert(COUNT_FLAG_TYPES == 4, "Exhaustive flag type parsing");

--- a/flag.h
+++ b/flag.h
@@ -26,7 +26,7 @@
 
 char *flag_name(void *val);
 bool *flag_bool_null(const char *name, bool def, const char *desc, ...);
-#define flag_bool(name, def, desc) flag_bool_null(name, def, desc)
+#define flag_bool(name, def, desc) flag_bool_null(name, def, desc, NULL)
 #define flag_bool_aliases(name, def, desc, ...)                                        \
   flag_bool_null(name, def, desc, __VA_ARGS__, NULL)
 uint64_t *flag_uint64_null(const char *name, uint64_t def, const char *desc, ...);


### PR DESCRIPTION
- Add `aliases` and `alias_count` fields to the `Flag` struct
- Respect the aliases when parsing flags
- Print out aliases when printing out options
- Update example to feature this